### PR TITLE
remove postcss comments

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -12,6 +12,11 @@ export default async (src, options = {}) => {
   if (!processor) {
     processor = postcss(plugins)
   }
-  const result = await processor.process(src)
+  const result = await processor.process(src, {
+    map: {
+      inline: false,
+      annotation: false
+    }
+  })
   return result.css
 }


### PR DESCRIPTION
When using plugins like `postcss-next`, `postcss-inherit` it occurs to me, that the sourcemap is added, even in production builds.
This removes the comments completely.
It reduced our build size from 9.8M to 5.2M